### PR TITLE
Removing unused ffmpeg dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@material-ui/icons": "^4.2.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
-    "ffmpeg": "0.0.4",
     "firebase": "^7.1.0",
     "pre-commit": "^1.2.2",
     "react": "^16.9.0",


### PR DESCRIPTION
Ran npm run build and builds fine.

We can't use "ffmpeg" library as it is unlicensed - this library is also not being currently used.