### PR TITLE
Rename Theme Customisation --> Settings

### DIFF
--- a/src/navmenu/NavMenu.js
+++ b/src/navmenu/NavMenu.js
@@ -45,7 +45,7 @@ class NavMenu extends React.Component {
             {this.renderMenuItem("User Contributions", ROUTES.CONTRIBUTIONS)}
             {this.renderMenuItem("Sharing Links", ROUTES.SHARING)}
             {this.renderMenuItem("User Management", ROUTES.MANAGEMENT)}
-            {this.renderMenuItem("Theme Customization", ROUTES.THEME)}
+            {this.renderMenuItem("Settings", ROUTES.THEME)}
           </MenuList>
         );
     }else{


### PR DESCRIPTION
This was overridden by a previous merge - restoring this behaviour. Also rearranging to be in order for both moderator and administrator.